### PR TITLE
Create deployment configs as code

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "bun --watch src/index.ts",
     "build": "tsc -p tsconfig.json",
-    "start": "node dist/apps/api/src/index.js"
+    "start": "bun dist/src/index.js"
   },
   "dependencies": {
     "elysia": "^1.1.29",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,5 +9,6 @@ const app = new Elysia()
   .get('/', () => ({ ok: true }))
   .get('/hello', () => ({ message: helloDutch('World') }))
 
-app.listen({ port: 3000, hostname: '0.0.0.0' })
-console.log(`API running on http://localhost:3000`)
+const port = Bun.env.PORT ? Number(Bun.env.PORT) : 3000
+app.listen({ port, hostname: '0.0.0.0' })
+console.log(`API running on http://localhost:${port}`)

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "project": {
+    "name": "originals-monorepo"
+  },
+  "services": [
+    {
+      "name": "api",
+      "rootDirectory": "apps/api",
+      "build": {
+        "builder": "NIXPACKS",
+        "installCommand": "bun install --frozen-lockfile",
+        "buildCommand": "bun run build"
+      },
+      "startCommand": "bun run start",
+      "healthcheckPath": "/"
+    },
+    {
+      "name": "web",
+      "rootDirectory": "apps/web",
+      "build": {
+        "builder": "NIXPACKS",
+        "installCommand": "bun install --frozen-lockfile",
+        "buildCommand": "bun run build"
+      },
+      "startCommand": "bun x astro preview --port $PORT --host",
+      "healthcheckPath": "/"
+    }
+  ]
+}


### PR DESCRIPTION
Add Railway config-as-code (`railway.json`) for backend and frontend services, and update the API to use the `PORT` environment variable.

---
<a href="https://cursor.com/background-agent?bcId=bc-0aa3b63c-a29f-49a4-a96e-e1fd3c8d905d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0aa3b63c-a29f-49a4-a96e-e1fd3c8d905d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

