### PR TITLE
Add allowed host to vite config

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -1,5 +1,8 @@
 import { defineConfig } from 'astro/config'
 
 export default defineConfig({
-  server: { port: 4321, host: true }
+  server: { port: 4321, host: true },
+  preview: {
+    allowedHosts: ['dutch-production.up.railway.app']
+  }
 })


### PR DESCRIPTION
Add `dutch-production.up.railway.app` to `preview.allowedHosts` in `astro.config.mjs` to resolve a host not allowed error.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1f44597-7f54-4eb1-b44f-0cd6c2648b33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b1f44597-7f54-4eb1-b44f-0cd6c2648b33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

