### PR TITLE
Add hostname to api server config

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,12 +9,12 @@ const app = new Elysia()
   .get('/', () => ({ ok: true }))
   .get('/hello', () => ({ message: helloDutch('World') }))
 
-const hostname = Bun.env.HOST ?? '0.0.0.0'
+const hostname = Bun.env.HOST ?? '::'
 let port = Bun.env.PORT ? parseInt(Bun.env.PORT, 10) : 3000
 if (isNaN(port)) {
   console.error('Invalid PORT environment variable. Using default port 3000.')
   port = 3000
 }
 app.listen({ port, hostname })
-const advertisedHost = hostname === '0.0.0.0' ? '127.0.0.1' : hostname
+const advertisedHost = hostname === '::' ? '[::1]' : hostname
 console.log(`API listening on http://${advertisedHost}:${port}`)


### PR DESCRIPTION
Add a reverse proxy to the web server to serve the API under `/api/*` and bind both services to IPv6 for Railway's single hostname constraint.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc207fd5-4932-4455-a031-e48208c59e4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dc207fd5-4932-4455-a031-e48208c59e4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

