### PR TITLE
Add ci for bun and turbo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.2.22'
+
+      - name: Cache Bun cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/bun
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Cache Turborepo outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('**/bun.lockb', '**/turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-${{ hashFiles('**/bun.lockb') }}-
+            ${{ runner.os }}-turbo-
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build
+        run: bun run build
+
+      - name: Test (prefer turbo if available)
+        shell: bash
+        run: |
+          set -euo pipefail
+          if bun x turbo --version >/dev/null 2>&1; then
+            bun x turbo run test --continue
+          else
+            bun test
+          fi
+


### PR DESCRIPTION
Add GitHub Actions CI to automate Bun-based install, build, and test across all workspaces with Turborepo caching.

---
<a href="https://cursor.com/background-agent?bcId=bc-719ac99a-ed18-4453-817e-8bee5cfffce5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-719ac99a-ed18-4453-817e-8bee5cfffce5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

