### PR TITLE
Fix web package build error

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -12,11 +12,11 @@ export default defineConfig({
   vite: {
     build: {
       rollupOptions: {
-        external: ['bun:sqlite']
+        external: ['bun:sqlite', 'bun:test']
       }
     },
     optimizeDeps: {
-      exclude: ['bun:sqlite']
+      exclude: ['bun:sqlite', 'bun:test']
     }
   }
 })

--- a/apps/web/tests/api-proxy.e2e.test.ts
+++ b/apps/web/tests/api-proxy.e2e.test.ts
@@ -5,7 +5,7 @@ let webStop: (() => void) | undefined
 let webOrigin = ''
 
 async function startApi(): Promise<string> {
-  const mod = await import('../../../api/src/index.ts')
+  const mod = await import('../../api/src/index.ts')
   const app = mod.createApp()
   const server = app.listen({ hostname: '127.0.0.1', port: 0 })
   const port = (server as any)?.port ?? (server as any)?.server?.port ?? 0
@@ -20,7 +20,7 @@ async function startWeb(apiOrigin: string): Promise<string> {
   ;(globalThis as any).process.env.HOST = '127.0.0.1'
   ;(globalThis as any).process.env.PORT = String(PORT)
   ;(globalThis as any).process.env.API_INTERNAL_ORIGIN = apiOrigin
-  const mod: any = await import('../../server.ts')
+  const mod: any = await import('../src/server.ts')
   const srv = mod.server
   webStop = () => srv?.stop?.()
 


### PR DESCRIPTION
Move web E2E test out of `src/pages` and externalize `bun:test` to fix build failure.

The Astro build for `@originals/web` was failing because a test file (`api-proxy.e2e.test.ts`) was located in `src/pages`, causing Vite/Rollup to attempt to bundle `bun:test`, which is a Bun-specific module and not resolvable by Vite. Moving the test file and explicitly excluding `bun:test` from the Vite configuration resolves this issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4c797f4-2461-4f33-8373-d16e96342def"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e4c797f4-2461-4f33-8373-d16e96342def"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

