### PR TITLE
Fix tailwind build compilation

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev --port 4321 --host",
     "build": "astro build",
-    "start": "bun --port 4321 --host=0.0.0.0 dist/index.html"
+    "start": "astro preview --host --port 4321"
   },
   "dependencies": {
     "@astrojs/react": "^4.4.0",


### PR DESCRIPTION
Update the `start` script to use `astro preview` to correctly serve built Tailwind CSS assets.

The previous `start` command `bun --port 4321 --host=0.0.0.0 dist/index.html` did not correctly serve Astro's routed assets, preventing the built Tailwind CSS from loading. Switching to `astro preview` ensures all assets are served correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-eae88432-3b99-4e44-8361-fe9e7f884a4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eae88432-3b99-4e44-8361-fe9e7f884a4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

