### PR TITLE
Add site navigation header

### DIFF
--- a/apps/web/src/components/ui/Header.astro
+++ b/apps/web/src/components/ui/Header.astro
@@ -1,0 +1,19 @@
+---
+import WalletButton from './WalletButton'
+---
+
+<header class="border-b bg-white/80 backdrop-blur dark:border-gray-900 dark:bg-gray-900/80">
+  <div class="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
+    <a href="/" class="flex items-center gap-2 text-lg font-semibold">
+      <span class="inline-block h-6 w-6 rounded bg-black dark:bg-white"></span>
+      <span>Originals</span>
+    </a>
+    <nav class="flex items-center gap-3 text-sm">
+      <a href="/auctions" class="text-gray-700 hover:text-black dark:text-gray-300 dark:hover:text-white">Auctions</a>
+      <a href="/auctions/new" class="text-gray-700 hover:text-black dark:text-gray-300 dark:hover:text-white">Create</a>
+      <a href="/docs/auction-type" class="text-gray-700 hover:text-black dark:text-gray-300 dark:hover:text-white">Docs</a>
+      <a href="https://github.com" class="text-gray-700 hover:text-black dark:text-gray-300 dark:hover:text-white" rel="noreferrer" target="_blank">GitHub</a>
+      <WalletButton client:load />
+    </nav>
+  </div>
+</header>

--- a/apps/web/src/pages/auction.astro
+++ b/apps/web/src/pages/auction.astro
@@ -2,17 +2,25 @@
 import React from 'react'
 import AuctionTypeSelectorDemo from '../components/auction/AuctionTypeSelectorDemo'
 import DutchEditorDemo from '../components/auction/DutchEditorDemo'
-
+import Header from '../components/ui/Header.astro'
+import { WalletProvider } from '../lib/wallet/WalletContext'
+import { ToastProvider } from '../lib/toast/ToastContext'
+import ToastContainer from '../components/ui/ToastContainer'
+import '../styles/globals.css'
 ---
 <html>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Auction Components Demo</title>
+    <title>Auction Components Demo - Originals</title>
   </head>
-  <body>
-    <main style="padding: 24px; max-width: 920px; margin: 0 auto;">
-      <h1 style="font-size: 1.5rem; font-weight: 700;">Auction Components Demo</h1>
+  <body class="min-h-screen bg-gray-50 dark:bg-gray-950">
+    <ToastProvider client:load>
+      <WalletProvider client:load>
+        <ToastContainer client:load />
+        <Header />
+        <main style="padding: 24px; max-width: 920px; margin: 0 auto;">
+          <h1 style="font-size: 1.5rem; font-weight: 700;">Auction Components Demo</h1>
 
       <section style="margin-top: 20px;">
         <h2 style="font-size: 1.25rem; font-weight: 600;">Auction Type Selector</h2>
@@ -23,6 +31,8 @@ import DutchEditorDemo from '../components/auction/DutchEditorDemo'
         <h2 style="font-size: 1.25rem; font-weight: 600;">Dutch Price Schedule Editor</h2>
         <DutchEditorDemo client:load />
       </section>
-    </main>
+        </main>
+      </WalletProvider>
+    </ToastProvider>
   </body>
 </html>

--- a/apps/web/src/pages/auctions/index.astro
+++ b/apps/web/src/pages/auctions/index.astro
@@ -1,8 +1,12 @@
 ---
 import '../../styles/globals.css'
+import Header from '../../components/ui/Header.astro'
 import Filters from '../../components/auctions/Filters'
 import List from '../../components/auctions/List'
 import { parseQueryFromSearch } from '../../lib/auctions/common'
+import { WalletProvider } from '../../lib/wallet/WalletContext'
+import { ToastProvider } from '../../lib/toast/ToastContext'
+import ToastContainer from '../../components/ui/ToastContainer'
 
 const search = Astro.url.searchParams
 const q = parseQueryFromSearch(search)
@@ -16,16 +20,20 @@ const initial = undefined
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Auctions - Originals</title>
   </head>
-  <body>
-    <main class="min-h-screen bg-gray-50 p-4 dark:bg-gray-900">
-      <div class="mx-auto max-w-6xl space-y-6">
-        <header class="flex items-end justify-between gap-4">
-          <div>
-            <h1 class="text-2xl font-semibold">Auctions</h1>
-            <p class="text-sm text-muted-foreground">Browse drafts, scheduled, live, and ended auctions.</p>
-          </div>
-          <a href="/auctions/new" class="button">New auction</a>
-        </header>
+  <body class="min-h-screen bg-gray-50 dark:bg-gray-950">
+    <ToastProvider client:load>
+      <WalletProvider client:load>
+        <ToastContainer client:load />
+        <Header />
+        <main class="p-4">
+          <div class="mx-auto max-w-6xl space-y-6">
+            <header class="flex items-end justify-between gap-4">
+              <div>
+                <h1 class="text-2xl font-semibold">Auctions</h1>
+                <p class="text-sm text-muted-foreground">Browse drafts, scheduled, live, and ended auctions.</p>
+              </div>
+              <a href="/auctions/new" class="button">New auction</a>
+            </header>
 
         <section aria-labelledby="filters-heading" class="rounded-lg border bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-800">
           <h2 id="filters-heading" class="sr-only">Filters</h2>
@@ -45,6 +53,8 @@ const initial = undefined
         </section>
       </div>
     </main>
+      </WalletProvider>
+    </ToastProvider>
   </body>
 </html>
 

--- a/apps/web/src/pages/auctions/new.astro
+++ b/apps/web/src/pages/auctions/new.astro
@@ -1,7 +1,7 @@
 ---
 import CreateAuctionWizard from '../../components/auction/CreateAuctionWizard';
 import { WalletProvider } from '../../lib/wallet/WalletContext';
-import WalletButton from '../../components/ui/WalletButton';
+import Header from '../../components/ui/Header.astro';
 import { ToastProvider } from '../../lib/toast/ToastContext';
 import ToastContainer from '../../components/ui/ToastContainer';
 import '../../styles/globals.css';
@@ -12,20 +12,20 @@ import '../../styles/globals.css';
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Create Auction - Originals</title>
   </head>
-  <body>
+  <body class="min-h-screen bg-gray-50 dark:bg-gray-950">
     <ToastProvider client:load>
       <WalletProvider client:load>
         <ToastContainer client:load />
-        <main class="min-h-screen bg-gray-50 dark:bg-gray-900">
+        <Header />
+        <main>
           <div class="mx-auto max-w-2xl px-4 py-8">
-            <nav class="mb-8 flex items-center justify-between">
+            <nav class="mb-8">
               <a 
                 href="/auctions" 
                 class="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 text-sm underline"
               >
                 ← Back to Auctions
               </a>
-              <WalletButton client:load />
             </nav>
             
             <div class="rounded-lg bg-white p-6 shadow-sm dark:bg-gray-800">

--- a/apps/web/src/pages/auctions/preview.astro
+++ b/apps/web/src/pages/auctions/preview.astro
@@ -1,6 +1,10 @@
 ---
 import '../../styles/globals.css';
 import Preview from '../../react/auctions/PreviewPage';
+import Header from '../../components/ui/Header.astro'
+import { WalletProvider } from '../../lib/wallet/WalletContext'
+import { ToastProvider } from '../../lib/toast/ToastContext'
+import ToastContainer from '../../components/ui/ToastContainer'
 const { searchParams } = Astro.url;
 const stateParam = searchParams.get('state');
 const typeParam = searchParams.get('type');
@@ -9,14 +13,20 @@ const typeParam = searchParams.get('type');
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Auction Preview</title>
+    <title>Auction Preview - Originals</title>
   </head>
-  <body>
-    <main class="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <div class="mx-auto max-w-5xl px-4 py-8">
-        <Preview client:only="react" stateParam={stateParam} typeParam={typeParam} />
-      </div>
-    </main>
+  <body class="min-h-screen bg-gray-50 dark:bg-gray-950">
+    <ToastProvider client:load>
+      <WalletProvider client:load>
+        <ToastContainer client:load />
+        <Header />
+        <main>
+          <div class="mx-auto max-w-5xl px-4 py-8">
+            <Preview client:only="react" stateParam={stateParam} typeParam={typeParam} />
+          </div>
+        </main>
+      </WalletProvider>
+    </ToastProvider>
   </body>
   </html>
 

--- a/apps/web/src/pages/auctions/view.astro
+++ b/apps/web/src/pages/auctions/view.astro
@@ -2,30 +2,40 @@
 import '../../styles/globals.css'
 import React from 'react'
 import AuctionView from '../../react/auctions/View'
+import Header from '../../components/ui/Header.astro'
+import { WalletProvider } from '../../lib/wallet/WalletContext'
+import { ToastProvider } from '../../lib/toast/ToastContext'
+import ToastContainer from '../../components/ui/ToastContainer'
 ---
 <html>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Auction</title>
+    <title>Auction - Originals</title>
   </head>
-  <body>
-    <main class="min-h-screen bg-gray-50 p-4 dark:bg-gray-900">
-      <div class="mx-auto max-w-4xl space-y-6">
-        <header class="flex items-end justify-between gap-4">
-          <div>
-            <h1 class="text-2xl font-semibold">Auction</h1>
-            <p class="text-sm text-muted-foreground">View auction details and current price.</p>
-          </div>
-          <div class="flex gap-2">
-            <a href="/auctions" class="button button-secondary">Back to auctions</a>
-            <a href="/auctions/new" class="button">New auction</a>
-          </div>
-        </header>
+  <body class="min-h-screen bg-gray-50 dark:bg-gray-950">
+    <ToastProvider client:load>
+      <WalletProvider client:load>
+        <ToastContainer client:load />
+        <Header />
+        <main class="p-4">
+          <div class="mx-auto max-w-4xl space-y-6">
+            <header class="flex items-end justify-between gap-4">
+              <div>
+                <h1 class="text-2xl font-semibold">Auction</h1>
+                <p class="text-sm text-muted-foreground">View auction details and current price.</p>
+              </div>
+              <div class="flex gap-2">
+                <a href="/auctions" class="button button-secondary">Back to auctions</a>
+                <a href="/auctions/new" class="button">New auction</a>
+              </div>
+            </header>
 
-        <AuctionView client:only="react" />
-      </div>
-    </main>
+            <AuctionView client:only="react" />
+          </div>
+        </main>
+      </WalletProvider>
+    </ToastProvider>
   </body>
   </html>
 

--- a/apps/web/src/pages/docs/auction-type.astro
+++ b/apps/web/src/pages/docs/auction-type.astro
@@ -1,16 +1,25 @@
 ---
 import AuctionTypeSelectorDemo from '../../components/auction/AuctionTypeSelectorDemo'
+import Header from '../../components/ui/Header.astro'
+import { WalletProvider } from '../../lib/wallet/WalletContext'
+import { ToastProvider } from '../../lib/toast/ToastContext'
+import ToastContainer from '../../components/ui/ToastContainer'
+import '../../styles/globals.css'
 ---
 
 <html>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>AuctionTypeSelector Usage</title>
+    <title>AuctionTypeSelector Usage - Originals</title>
   </head>
-  <body>
-    <main style="padding: 24px; max-width: 820px; margin: 0 auto;">
-      <h1 style="font-size: 1.5rem; font-weight: 700;">AuctionTypeSelector</h1>
+  <body class="min-h-screen bg-gray-50 dark:bg-gray-950">
+    <ToastProvider client:load>
+      <WalletProvider client:load>
+        <ToastContainer client:load />
+        <Header />
+        <main style="padding: 24px; max-width: 820px; margin: 0 auto;">
+          <h1 style="font-size: 1.5rem; font-weight: 700;">AuctionTypeSelector</h1>
       <p>The selector uses accessible radio semantics and emits <code>onChange('english'|'dutch')</code>. Provide a docs link via the optional <code>docsSlot</code>.</p>
       <AuctionTypeSelectorDemo client:load />
       <h2 style="margin-top:16px; font-weight:600;">Props</h2>
@@ -19,6 +28,8 @@ import AuctionTypeSelectorDemo from '../../components/auction/AuctionTypeSelecto
         <li><code>onChange</code>: callback with new value</li>
         <li><code>docsSlot</code>: optional React node for help/docs link</li>
       </ul>
-    </main>
+        </main>
+      </WalletProvider>
+    </ToastProvider>
   </body>
 </html>

--- a/apps/web/src/pages/docs/dutch-schedule.astro
+++ b/apps/web/src/pages/docs/dutch-schedule.astro
@@ -1,16 +1,25 @@
 ---
 import DemoDutchEditor from '../../components/auction/DemoDutchEditor'
+import Header from '../../components/ui/Header.astro'
+import { WalletProvider } from '../../lib/wallet/WalletContext'
+import { ToastProvider } from '../../lib/toast/ToastContext'
+import ToastContainer from '../../components/ui/ToastContainer'
+import '../../styles/globals.css'
 ---
 
 <html>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>DutchPriceScheduleEditor Usage</title>
+    <title>DutchPriceScheduleEditor Usage - Originals</title>
   </head>
-  <body>
-    <main style="padding: 24px; max-width: 820px; margin: 0 auto;">
-      <h1 style="font-size: 1.5rem; font-weight: 700;">DutchPriceScheduleEditor</h1>
+  <body class="min-h-screen bg-gray-50 dark:bg-gray-950">
+    <ToastProvider client:load>
+      <WalletProvider client:load>
+        <ToastContainer client:load />
+        <Header />
+        <main style="padding: 24px; max-width: 820px; margin: 0 auto;">
+          <h1 style="font-size: 1.5rem; font-weight: 700;">DutchPriceScheduleEditor</h1>
       <p>A controlled editor with live SVG sparkline preview. Emits a normalized schedule with <code>points</code> and <code>errors</code>.</p>
       <DemoDutchEditor client:load />
       <h2 style="margin-top:16px; font-weight:600;">Validation</h2>
@@ -19,6 +28,8 @@ import DemoDutchEditor from '../../components/auction/DemoDutchEditor'
         <li>durationSeconds &gt; 0</li>
         <li>intervalSeconds &gt; 0 and divides duration</li>
       </ul>
-    </main>
+        </main>
+      </WalletProvider>
+    </ToastProvider>
   </body>
 </html>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -2,7 +2,7 @@
 import '../styles/globals.css'
 import DemoDutchEditor from '../components/auction/DemoDutchEditor'
 import LiveAuctionsSection from '../components/auction/LiveAuctionsSection'
-import WalletButton from '../components/ui/WalletButton'
+import Header from '../components/ui/Header.astro'
 import { WalletProvider } from '../lib/wallet/WalletContext'
 import { ToastProvider } from '../lib/toast/ToastContext'
 import ToastContainer from '../components/ui/ToastContainer'
@@ -17,20 +17,7 @@ import ToastContainer from '../components/ui/ToastContainer'
     <ToastProvider client:load>
       <WalletProvider client:load>
         <ToastContainer client:load />
-        <header class="border-b bg-white/80 backdrop-blur dark:border-gray-900 dark:bg-gray-900/80">
-        <div class="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
-          <a href="/" class="flex items-center gap-2 text-lg font-semibold">
-            <span class="inline-block h-6 w-6 rounded bg-black dark:bg-white"></span>
-            <span>Originals</span>
-          </a>
-          <nav class="flex items-center gap-3 text-sm">
-            <a href="/auctions" class="text-gray-700 hover:text-black dark:text-gray-300 dark:hover:text-white">Auctions</a>
-            <a href="/docs/auction-type" class="text-gray-700 hover:text-black dark:text-gray-300 dark:hover:text-white">Docs</a>
-            <a href="https://github.com" class="text-gray-700 hover:text-black dark:text-gray-300 dark:hover:text-white" rel="noreferrer" target="_blank">GitHub</a>
-            <WalletButton client:load />
-          </nav>
-        </div>
-      </header>
+        <Header />
 
     <main>
        <!-- Quick Actions -->

--- a/apps/web/src/pages/styles.astro
+++ b/apps/web/src/pages/styles.astro
@@ -1,17 +1,26 @@
 ---
 import '../styles/globals.css'
+import Header from '../components/ui/Header.astro'
+import { WalletProvider } from '../lib/wallet/WalletContext'
+import { ToastProvider } from '../lib/toast/ToastContext'
+import ToastContainer from '../components/ui/ToastContainer'
 ---
 <html>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Design System</title>
+    <title>Design System - Originals</title>
   </head>
-  <body class="p-6 space-y-10">
-    <header class="flex items-center justify-between">
-      <h1 class="text-3xl font-bold tracking-tight">Design System</h1>
-      <button id="theme-toggle" class="btn-ghost">Toggle theme</button>
-    </header>
+  <body class="min-h-screen bg-gray-50 dark:bg-gray-950">
+    <ToastProvider client:load>
+      <WalletProvider client:load>
+        <ToastContainer client:load />
+        <Header />
+        <div class="p-6 space-y-10">
+          <header class="flex items-center justify-between">
+            <h1 class="text-3xl font-bold tracking-tight">Design System</h1>
+            <button id="theme-toggle" class="btn-ghost">Toggle theme</button>
+          </header>
 
     <section>
       <h2 class="text-xl font-semibold mb-4">Colors</h2>
@@ -98,6 +107,9 @@ import '../styles/globals.css'
         document.documentElement.classList.toggle('dark');
       });
     </script>
+        </div>
+      </WalletProvider>
+    </ToastProvider>
   </body>
   </html>
 


### PR DESCRIPTION
Add a consistent, reusable header with navigation and wallet functionality to all application pages.

The initial request was to add a header for navigation. Upon inspection, it was found that only the homepage had a header, and other pages lacked consistent navigation. This PR addresses that by creating a single, reusable `Header` component and applying it to all pages. It also ensures necessary context providers (WalletProvider, ToastProvider) are present on all pages to support the header's functionality and general application features, and standardizes page titles.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b51126b-0ea3-4ef8-a717-ebc007622ee2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8b51126b-0ea3-4ef8-a717-ebc007622ee2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

